### PR TITLE
Fix references to GpuParallelSampler

### DIFF
--- a/examples/example_4.py
+++ b/examples/example_4.py
@@ -15,7 +15,7 @@ is optimizing.  Feedforward agents are compatible with this arrangement by same
 use of 'valid' mask.
 
 """
-from rlpyt.samplers.parallel.gpu.sampler import GpuParallelSampler
+from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
 from rlpyt.samplers.parallel.gpu.collectors import (GpuResetCollector,
     GpuWaitResetCollector)
 from rlpyt.envs.atari.atari_env import AtariEnv
@@ -30,7 +30,7 @@ def build_and_train(game="pong", run_ID=0, cuda_idx=None, mid_batch_reset=False,
     Collector = GpuResetCollector if mid_batch_reset else GpuWaitResetCollector
     print(f"To satisfy mid_batch_reset=={mid_batch_reset}, using {Collector}.")
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=dict(game=game, num_img_obs=1),  # Learn on individual frames.
         CollectorCls=Collector,

--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -8,7 +8,7 @@ should improve the efficiency of the forward/backward passes during training.
 
 """
 
-from rlpyt.samplers.parallel.gpu.sampler import GpuParallelSampler
+from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
 from rlpyt.samplers.parallel.gpu.collectors import GpuWaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv
 from rlpyt.algos.dqn.dqn import DQN
@@ -23,7 +23,7 @@ def build_and_train(game="pong", run_ID=0, cuda_idx=None, n_parallel=2):
         algo=dict(batch_size=128),
         sampler=dict(batch_T=2, batch_B=32),
     )
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=dict(game=game),
         CollectorCls=GpuWaitResetCollector,

--- a/examples/example_7.py
+++ b/examples/example_7.py
@@ -16,7 +16,7 @@ Try different affinity inputs to see where the jobs run on the machine.
 
 """
 from rlpyt.utils.launching.affinity import make_affinity
-from rlpyt.samplers.parallel.gpu.sampler import GpuParallelSampler
+from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
 from rlpyt.samplers.parallel.gpu.collectors import GpuWaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv
 from rlpyt.algos.pg.a2c import A2C
@@ -39,7 +39,7 @@ def build_and_train(game="pong", run_ID=0):
         # cpu_per_run=1,
     )
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=dict(game=game),
         CollectorCls=GpuWaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.cat_dqn import CategoricalDQN
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.dqn import DQN
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu_noeval.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu_noeval.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.dqn import DQN
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.r2d1 import R2D1
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/pg/train/atari_lstm_ppo_gpu.py
+++ b/rlpyt/experiments/scripts/atari/pg/train/atari_lstm_ppo_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.pg.ppo import PPO
@@ -20,7 +20,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     variant = load_variant(log_dir)
     config = update_config(config, variant)
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_gpu.py
+++ b/rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import ResetCollector
 from rlpyt.envs.gym import make as gym_make
 from rlpyt.algos.pg.ppo import PPO
@@ -20,7 +20,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     variant = load_variant(log_dir)
     config = update_config(config, variant)
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=gym_make,
         env_kwargs=config["env"],
         CollectorCls=ResetCollector,


### PR DESCRIPTION
A bunch of examples still reference `GpuParallelSampler` which does not exist anymore.