### PR TITLE
Fix references to n_cpu_cores

### DIFF
--- a/examples/example_4.py
+++ b/examples/example_4.py
@@ -15,7 +15,7 @@ is optimizing.  Feedforward agents are compatible with this arrangement by same
 use of 'valid' mask.
 
 """
-from rlpyt.samplers.parallel.gpu.sampler import GpuParallelSampler
+from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
 from rlpyt.samplers.parallel.gpu.collectors import (GpuResetCollector,
     GpuWaitResetCollector)
 from rlpyt.envs.atari.atari_env import AtariEnv
@@ -30,7 +30,7 @@ def build_and_train(game="pong", run_ID=0, cuda_idx=None, mid_batch_reset=False,
     Collector = GpuResetCollector if mid_batch_reset else GpuWaitResetCollector
     print(f"To satisfy mid_batch_reset=={mid_batch_reset}, using {Collector}.")
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=dict(game=game, num_img_obs=1),  # Learn on individual frames.
         CollectorCls=Collector,

--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -8,7 +8,7 @@ should improve the efficiency of the forward/backward passes during training.
 
 """
 
-from rlpyt.samplers.parallel.gpu.sampler import GpuParallelSampler
+from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
 from rlpyt.samplers.parallel.gpu.collectors import GpuWaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv
 from rlpyt.algos.dqn.dqn import DQN
@@ -23,7 +23,7 @@ def build_and_train(game="pong", run_ID=0, cuda_idx=None, n_parallel=2):
         algo=dict(batch_size=128),
         sampler=dict(batch_T=2, batch_B=32),
     )
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=dict(game=game),
         CollectorCls=GpuWaitResetCollector,

--- a/examples/example_7.py
+++ b/examples/example_7.py
@@ -31,7 +31,7 @@ def build_and_train(game="pong", run_ID=0):
     # Change these inputs to match local machine and desired parallelism.
     affinity = make_affinity(
         run_slot=0,
-        n_cpu_cores=16,  # Use 16 cores across all experiments.
+        n_cpu_core=16,  # Use 16 cores across all experiments.
         n_gpu=8,  # Use 8 gpus across all experiments.
         hyperthread_offset=24,  # If machine has 24 cores.
         n_socket=2,  # Presume CPU socket affinity to lower/upper half GPUs.

--- a/examples/example_7.py
+++ b/examples/example_7.py
@@ -16,7 +16,7 @@ Try different affinity inputs to see where the jobs run on the machine.
 
 """
 from rlpyt.utils.launching.affinity import make_affinity
-from rlpyt.samplers.parallel.gpu.sampler import GpuParallelSampler
+from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
 from rlpyt.samplers.parallel.gpu.collectors import GpuWaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv
 from rlpyt.algos.pg.a2c import A2C
@@ -39,7 +39,7 @@ def build_and_train(game="pong", run_ID=0):
         # cpu_per_run=1,
     )
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=dict(game=game),
         CollectorCls=GpuWaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_dqn_cpu_basic_1of2.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_dqn_cpu_basic_1of2.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_dqn_cpu_basic_2of2.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_dqn_cpu_basic_2of2.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_dqn_gpu_pong.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_dqn_gpu_pong.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_r2d1_long_4tr_gravitar.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/got/launch_atari_r2d1_long_4tr_gravitar.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=12,
+    n_cpu_core=12,
     n_gpu=1,
     hyperthread_offset=20,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_catdqn_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_catdqn_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dpd_dqn_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dpd_dqn_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dqn_cpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dqn_cpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dqn_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dqn_gpu.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dqn_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_dqn_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_ernbw_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_ernbw_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_r2d1_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/launch_atari_r2d1_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=1,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_catdqn_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_catdqn_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dpd_dqn_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dpd_dqn_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_cpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_cpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=6,
     # hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_gpu_noeval.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_gpu_noeval.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu_noeval.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_serial.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_dqn_serial.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_serial.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_ernbw_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_ernbw_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_asteroids.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_asteroids.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=2,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_chopper_command.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_chopper_command.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=2,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_gravitar.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_gravitar.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=2,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_seaquest.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_4tr_seaquest.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=2,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_gt_ad.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_gt_ad.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=4,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_sq_cc.py
+++ b/rlpyt/experiments/scripts/atari/dqn/launch/pabti/launch_atari_r2d1_long_sq_cc.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=24,
+    n_cpu_core=24,
     n_gpu=4,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_catdqn_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.cat_dqn import CategoricalDQN
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.dqn import DQN
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu_noeval.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_dqn_gpu_noeval.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.dqn import DQN
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py
+++ b/rlpyt/experiments/scripts/atari/dqn/train/atari_r2d1_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.r2d1 import R2D1
@@ -21,7 +21,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     config = update_config(config, variant)
     config["eval_env"]["game"] = config["env"]["game"]
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_ff_a2c_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_ff_a2c_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_a2c_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2

--- a/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_ff_a2c_gpu_low_lr.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_ff_a2c_gpu_low_lr.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_a2c_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2

--- a/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_ff_ppo_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_ff_ppo_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_ppo_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2

--- a/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_lstm_a2c_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_lstm_a2c_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_lstm_a2c_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2

--- a/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_lstm_ppo_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/got/launch_atari_lstm_ppo_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_lstm_ppo_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=4,
     hyperthread_offset=20,
     n_socket=2

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_a2c_cpu.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_a2c_cpu.py
@@ -6,7 +6,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_a2c_cpu.py"
 default_config_key = "0"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_a2c_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_a2c_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_a2c_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_a2c_gpu_multi.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_a2c_gpu_multi.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_a2c_gpu_multi.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=8,
+    n_cpu_core=8,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_ppo_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_ff_ppo_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_ppo_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_a2c_cpu.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_a2c_cpu.py
@@ -6,7 +6,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_lstm_a2c_cpu.py"
 # default_config_key = "0"
 affinity_code = encode_affinity(  # Let it be kwargs?
-    n_cpu_cores=6,
+    n_cpu_core=6,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_a2c_gpu.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_a2c_gpu.py
@@ -6,7 +6,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_lstm_a2c_gpu.py"
 # default_config_key = "0"
 affinity_code = encode_affinity(
-    n_cpu_cores=6,
+    n_cpu_core=6,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_a2c_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_a2c_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_lstm_a2c_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_ppo_gpu_basic.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/launch_atari_lstm_ppo_gpu_basic.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_lstm_ppo_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=4,
+    n_cpu_core=4,
     n_gpu=2,
     hyperthread_offset=8,
     n_socket=1,

--- a/rlpyt/experiments/scripts/atari/pg/launch/pabti/launch_atari_ff_a2c_gpu_multi.py
+++ b/rlpyt/experiments/scripts/atari/pg/launch/pabti/launch_atari_ff_a2c_gpu_multi.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/atari/pg/train/atari_ff_a2c_gpu_multi.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     hyperthread_offset=24,
     n_socket=2,

--- a/rlpyt/experiments/scripts/atari/pg/train/atari_lstm_ppo_gpu.py
+++ b/rlpyt/experiments/scripts/atari/pg/train/atari_lstm_ppo_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import WaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.pg.ppo import PPO
@@ -20,7 +20,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     variant = load_variant(log_dir)
     config = update_config(config, variant)
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=AtariEnv,
         env_kwargs=config["env"],
         CollectorCls=WaitResetCollector,

--- a/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_a2c_cpu.py
+++ b/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_a2c_cpu.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_a2c_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_ppo_cpu.py
+++ b/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_ppo_cpu.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_ppo_gpu.py
+++ b/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_ppo_gpu.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_gpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_ppo_serial.py
+++ b/rlpyt/experiments/scripts/mujoco/pg/launch/launch_mujoco_ppo_serial.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_serial.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_gpu.py
+++ b/rlpyt/experiments/scripts/mujoco/pg/train/mujoco_ff_ppo_gpu.py
@@ -2,7 +2,7 @@
 import sys
 
 from rlpyt.utils.launching.affinity import affinity_from_code
-from rlpyt.samplers.gpu.parallel_sampler import GpuParallelSampler
+from rlpyt.samplers.gpu.parallel_sampler import GpuSampler
 from rlpyt.samplers.gpu.collectors import ResetCollector
 from rlpyt.envs.gym import make as gym_make
 from rlpyt.algos.pg.ppo import PPO
@@ -20,7 +20,7 @@ def build_and_train(slot_affinity_code, log_dir, run_ID, config_key):
     variant = load_variant(log_dir)
     config = update_config(config, variant)
 
-    sampler = GpuParallelSampler(
+    sampler = GpuSampler(
         EnvCls=gym_make,
         env_kwargs=config["env"],
         CollectorCls=ResetCollector,

--- a/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_ddpg_cpu.py
+++ b/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_ddpg_cpu.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/qpg/train/mujoco_ddpg_cpu.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_ddpg_serial.py
+++ b/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_ddpg_serial.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/qpg/train/mujoco_ddpg_serial.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_ddpg_td3_sac_serial.py
+++ b/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_ddpg_td3_sac_serial.py
@@ -4,7 +4,7 @@ from rlpyt.utils.launching.exp_launcher import run_experiments
 from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_sac_serial.py
+++ b/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_sac_serial.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/qpg/train/mujoco_sac_serial.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_td3_serial.py
+++ b/rlpyt/experiments/scripts/mujoco/qpg/launch/launch_mujoco_td3_serial.py
@@ -5,7 +5,7 @@ from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 script = "rlpyt/experiments/scripts/mujoco/qpg/train/mujoco_td3_serial.py"
 affinity_code = encode_affinity(
-    n_cpu_cores=2,
+    n_cpu_core=2,
     n_gpu=0,
     hyperthread_offset=2,
     n_socket=1,

--- a/rlpyt/experiments/scripts/mujoco/qpg/launch/pabti/launch_mujoco_ddpg_td3_sac_serial.py
+++ b/rlpyt/experiments/scripts/mujoco/qpg/launch/pabti/launch_mujoco_ddpg_td3_sac_serial.py
@@ -4,7 +4,7 @@ from rlpyt.utils.launching.exp_launcher import run_experiments
 from rlpyt.utils.launching.variant import make_variants, VariantLevel
 
 affinity_code = encode_affinity(
-    n_cpu_cores=16,
+    n_cpu_core=16,
     n_gpu=8,
     contexts_per_gpu=2,
     hyperthread_offset=24,


### PR DESCRIPTION
A bunch of places are calling `make_affinity` with an `n_cpu_cores` argument. I believe this should be `n_cpu_core` instead. This PR is on top of https://github.com/astooke/rlpyt/pull/18.