### PR TITLE
fixes mismatching dimension error with agent outputs in collector

### DIFF
--- a/rlpyt/samplers/buffer.py
+++ b/rlpyt/samplers/buffer.py
@@ -1,6 +1,7 @@
 
 import multiprocessing as mp
 import numpy as np
+import torch
 
 from rlpyt.utils.buffer import buffer_from_example, torchify_buffer
 from rlpyt.agents.base import AgentInputs
@@ -70,10 +71,8 @@ def get_example_outputs(agent, env, examples, subprocess=False):
     r = np.asarray(r, dtype="float32")  # Must match torch float dtype here.
     agent.reset()
     agent_inputs = torchify_buffer(AgentInputs(o, a, r))
-    agent_inputs = AgentInputs(*map(lambda x: x.unsqueeze(dim=0), agent_inputs))
-    a, agent_info = agent.step(*agent_inputs)
-    a = a.squeeze(0)
-    agent_info = namedarraytuple_like(agent_info)(*map(lambda x: x.squeeze(dim=0), agent_info))
+    agent_inputs = add_dim_to_buffer(agent_inputs)
+    a, agent_info = remove_dim_to_buffer(agent.step(*agent_inputs))
     if "prev_rnn_state" in agent_info:
         # Agent leaves B dimension in, strip it: [B,N,H] --> [N,H]
         agent_info = agent_info._replace(prev_rnn_state=agent_info.prev_rnn_state[0])
@@ -83,3 +82,29 @@ def get_example_outputs(agent, env, examples, subprocess=False):
     examples["env_info"] = env_info
     examples["action"] = a  # OK to put torch tensor here, could numpify.
     examples["agent_info"] = agent_info
+
+
+def add_dim_to_buffer(buffer_):
+    if buffer_ is None:
+        return
+    if isinstance(buffer_, np.ndarray):
+        return torch.unsqueeze(torch.from_numpy(buffer_), dim=0)
+    elif isinstance(buffer_, torch.Tensor):
+        return torch.unsqueeze(buffer_, dim=0)
+    contents = tuple(add_dim_to_buffer(b) for b in buffer_)
+    if type(buffer_) is tuple:  # tuple, namedtuple instantiate differently.
+        return contents
+    return type(buffer_)(*contents)
+
+
+def remove_dim_to_buffer(buffer_):
+    if buffer_ is None:
+        return
+    if isinstance(buffer_, np.ndarray):
+        return torch.squeeze(torch.from_numpy(buffer_), dim=0)
+    elif isinstance(buffer_, torch.Tensor):
+        return torch.squeeze(buffer_, dim=0)
+    contents = tuple(remove_dim_to_buffer(b) for b in buffer_)
+    if type(buffer_) is tuple:  # tuple, namedtuple instantiate differently.
+        return contents
+    return type(buffer_)(*contents)

--- a/rlpyt/utils/logging/context.py
+++ b/rlpyt/utils/logging/context.py
@@ -22,10 +22,6 @@ def logger_context(log_dir, run_ID, name, log_params=None, snapshot_mode="none")
     logger.set_log_tabular_only(False)
     log_dir = osp.join(log_dir, f"run_{run_ID}")
     exp_dir = osp.abspath(log_dir)
-    if LOG_DIR != osp.commonpath([exp_dir, LOG_DIR]):
-        print(f"logger_context received log_dir outside of {LOG_DIR}: "
-            f"prepending by {LOG_DIR}/local/<yyyymmdd>/")
-        exp_dir = get_log_dir(log_dir)
     tabular_log_file = osp.join(exp_dir, "progress.csv")
     text_log_file = osp.join(exp_dir, "debug.log")
     params_log_file = osp.join(exp_dir, "params.json")


### PR DESCRIPTION
fixes #43 
error was caused by get_example_outputs() not adding batch dimension to
agent inputs. This caused some models to return a batch dimension and
others not.

get_example_outputs() now adds a batch dimension to the agent inputs and
then removes it again from the agent outputs before returning them.