### PR TITLE
np_mp_array fix and NamedTupleSchema updates

### DIFF
--- a/rlpyt/utils/array.py
+++ b/rlpyt/utils/array.py
@@ -48,7 +48,7 @@ def infer_leading_dims(array, dim):
     where found.
     """
     assert array.ndim in (dim, dim + 1, dim + 2)
-    shape = array.shape[-dim:]
+    shape = array.shape[len(array.shape) - dim:]
     T = B = 1
     has_T = has_B = False
     if array.ndim == dim + 2:

--- a/rlpyt/utils/buffer.py
+++ b/rlpyt/utils/buffer.py
@@ -4,12 +4,12 @@ import multiprocessing as mp
 import ctypes
 import torch
 
-from rlpyt.utils.collections import (namedarraytuple_like,
-    NamedArrayTupleSchema_like)
+from rlpyt.utils.collections import (NamedArrayTuple, namedarraytuple_like,
+    NamedArrayTupleSchema_like, NamedTuple)
 
 
 def buffer_from_example(example, leading_dims, share_memory=False,
-        use_NatSchema=False):
+        use_NatSchema=None):
     """Allocates memory and returns it in `namedarraytuple` with same
     structure as ``examples``, which should be a `namedtuple` or
     `namedarraytuple`. Applies the same leading dimensions ``leading_dims`` to
@@ -19,10 +19,13 @@ def buffer_from_example(example, leading_dims, share_memory=False,
     
     New: can use NamedArrayTuple types by the `use_NatSchema` flag, which
     may be easier for pickling/unpickling when using spawn instead
-    of fork.
+    of fork. If use_NatSchema is None, the type of ``example`` will be used to
+    infer what type to return (this is the default)
     """
     if example is None:
         return
+    if use_NatSchema is None:
+        use_NatSchema = isinstance(example, (NamedTuple, NamedArrayTuple))
     try:
         if use_NatSchema:
             buffer_type = NamedArrayTupleSchema_like(example)

--- a/rlpyt/utils/buffer.py
+++ b/rlpyt/utils/buffer.py
@@ -48,12 +48,58 @@ def build_array(example, leading_dims, share_memory=False):
     return constructor(shape=leading_dims + a.shape, dtype=a.dtype)
 
 
-def np_mp_array(shape, dtype):
-    """Allocate a numpy array on OS shared memory."""
-    size = int(np.prod(shape))
-    nbytes = size * np.dtype(dtype).itemsize
-    mp_array = mp.RawArray(ctypes.c_char, nbytes)
-    return np.frombuffer(mp_array, dtype=dtype, count=size).reshape(shape)
+class np_mp_array(np.ndarray):
+    """ndarray which can be shared between `multiprocessing` processes by
+    passing it to a `Process` init function (or similar). Note that this can
+    only be shared _on process startup_; it can't be passed through, e.g., a
+    queue at runtime. Also it cannot be pickled outside of multiprocessing's
+    internals."""
+    _shmem = None
+
+    def __new__(cls, shape, dtype=None, buffer=None, offset=None, strides=None,
+                order=None):
+        # init buffer
+        if buffer is None:
+            assert offset is None
+            assert strides is None
+            size = int(np.prod(shape))
+            nbytes = size * np.dtype(dtype).itemsize
+            # this is the part that can be passed between processes
+            shmem = mp.RawArray(ctypes.c_char, nbytes)
+            offset = 0
+        elif isinstance(buffer, ctypes.Array):
+            # restoring from a pickle
+            shmem = buffer
+        else:
+            raise ValueError(
+                f"{cls.__name__} does not support specifying custom "
+                f" buffers, but was given {buffer!r}")
+
+        # init array
+        obj = np.ndarray.__new__(cls, shape, dtype=dtype, buffer=shmem,
+                                 offset=offset, strides=strides, order=order)
+        obj._shmem = shmem
+
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is not None:
+            self._shmem = obj._shmem
+
+    def __reduce__(self):
+        # credit to https://stackoverflow.com/a/53534485 for awful/wonderful
+        # __array_interface__ hack
+        absolute_offset = self.__array_interface__['data'][0]
+        base_address = ctypes.addressof(self._shmem)
+        offset = absolute_offset - base_address
+        assert offset <= len(self._shmem), (offset, len(self._shmem))
+        order = 'FC'[self.flags['C_CONTIGUOUS']]
+        # buffer should get pickled by np
+        assert self._shmem is not None, \
+            "somehow this lost its _shmem reference"
+        newargs = (self.shape, self.dtype, self._shmem, offset, self.strides,
+                   order)
+        return (type(self), newargs)
 
 
 def torchify_buffer(buffer_):

--- a/rlpyt/utils/logging/console.py
+++ b/rlpyt/utils/logging/console.py
@@ -1,7 +1,6 @@
 import sys
 import time
 import os
-import errno
 import shlex
 import pydoc
 import inspect
@@ -32,13 +31,7 @@ def colorize(string, color, bold=False, highlight=False):
 
 
 def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
+    os.makedirs(path, exist_ok=True)
 
 
 def log(s):  # , send_telegram=False):

--- a/rlpyt/utils/logging/logger.py
+++ b/rlpyt/utils/logging/logger.py
@@ -118,7 +118,7 @@ def hold_tabular_output(file_name):
 
 
 def set_snapshot_dir(dir_name):
-    os.system("mkdir -p %s" % dir_name)
+    mkdir_p(dir_name)
     global _snapshot_dir
     _snapshot_dir = dir_name
 

--- a/rlpyt/utils/tensor.py
+++ b/rlpyt/utils/tensor.py
@@ -64,7 +64,7 @@ def infer_leading_dims(tensor, dim):
     else:
         T = 1
         B = 1 if lead_dim == 0 else tensor.shape[0]
-    shape = tensor.shape[-dim:]
+    shape = tensor.shape[lead_dim:]
     return lead_dim, T, B, shape
 
 


### PR DESCRIPTION
Per #99, this modifies `np_mp_array` to return an appropriate type when multiprocessing is using the "spawn" start method. It also makes three small changes that I needed to get my code running:

- Fix to `infer_leading_dims` for scalar data.
- Clean up directory creation code
- Make `buffer_from_example` infer the correct return type if no kwarg is given (otherwise it is necessary to modify the rlpyt internals if you want to use `NamedArrayTupleSchema`).