### PR TITLE
Update example_5.py to make it work without modifications (issue with GPU collector)

### DIFF
--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -9,7 +9,6 @@ should improve the efficiency of the forward/backward passes during training.
 """
 
 from rlpyt.samplers.parallel.gpu.sampler import GpuSampler
-from rlpyt.samplers.parallel.gpu.collectors import GpuWaitResetCollector
 from rlpyt.envs.atari.atari_env import AtariEnv, AtariTrajInfo
 from rlpyt.algos.dqn.dqn import DQN
 from rlpyt.agents.dqn.atari.atari_dqn_agent import AtariDqnAgent
@@ -27,7 +26,6 @@ def build_and_train(game="pong", run_ID=0, cuda_idx=None, n_parallel=2):
         EnvCls=AtariEnv,
         TrajInfoCls=AtariTrajInfo,
         env_kwargs=dict(game=game),
-        CollectorCls=GpuWaitResetCollector,
         eval_env_kwargs=dict(game=game),
         max_decorrelation_steps=0,
         eval_n_envs=10,


### PR DESCRIPTION
Hi Adam,

If I clone the current branch on master as of today, install following your instructions, and then run `python examples/example_5.py` it will run until the point when we have to start training. Then I get this error message in the logger:

```
2020-04-09 12:56:20.698844  | dqn_pong_0 itr #764 Optimizing over 15 iterations.
0% [##############################] 100% | ETA: 00:00:00
Total time elapsed: 00:00:00
2020-04-09 12:56:21.500512  | dqn_pong_0 itr #779 Evaluating agent...
2020-04-09 12:56:21.500667  | dqn_pong_0 itr #779 Agent at itr 779, eval eps 0.001
2020-04-09 12:56:21.500750  | dqn_pong_0 itr #779 Agent at itr 779, eval eps 0.001
2020-04-09 12:56:28.444518  | dqn_pong_0 itr #779 Evaluation reach max num trajectories (5).
2020-04-09 12:56:28.444959  | dqn_pong_0 itr #779 Evaluation runs complete.
2020-04-09 12:56:28.445058  | dqn_pong_0 itr #779 saving snapshot...
2020-04-09 12:56:28.445247  | dqn_pong_0 itr #779 saved
2020-04-09 12:56:28.447052  | -----------------------------  -------------
2020-04-09 12:56:28.447101  | Diagnostics/StepsInEval         7603
2020-04-09 12:56:28.447117  | Diagnostics/TrajsInEval           10
2020-04-09 12:56:28.447130  | Diagnostics/CumEvalTime          369.052
2020-04-09 12:56:28.447141  | Diagnostics/CumTrainTime          41.8431
2020-04-09 12:56:28.447153  | Diagnostics/Iteration            779
2020-04-09 12:56:28.447166  | Diagnostics/CumTime (s)          410.895
2020-04-09 12:56:28.447178  | Diagnostics/CumSteps           49920
2020-04-09 12:56:28.447190  | Diagnostics/CumCompletedTrajs     32
2020-04-09 12:56:28.447203  | Diagnostics/CumUpdates             0
2020-04-09 12:56:28.447216  | Diagnostics/StepsPerSecond      1192.96
2020-04-09 12:56:28.447228  | Diagnostics/UpdatesPerSecond       0
2020-04-09 12:56:28.447241  | Diagnostics/ReplayRatio            0
2020-04-09 12:56:28.447253  | Diagnostics/CumReplayRatio         0
2020-04-09 12:56:28.447267  | LengthAverage                    760.3
2020-04-09 12:56:28.447280  | LengthStd                          2.32594
2020-04-09 12:56:28.447293  | LengthMedian                     760.5
2020-04-09 12:56:28.447317  | LengthMin                        757
2020-04-09 12:56:28.447329  | LengthMax                        763
2020-04-09 12:56:28.447341  | ReturnAverage                    -21
2020-04-09 12:56:28.447354  | ReturnStd                          0
2020-04-09 12:56:28.447366  | ReturnMedian                     -21
2020-04-09 12:56:28.447379  | ReturnMin                        -21
2020-04-09 12:56:28.447391  | ReturnMax                        -21
2020-04-09 12:56:28.447404  | NonzeroRewardsAverage             21
2020-04-09 12:56:28.447416  | NonzeroRewardsStd                  0
2020-04-09 12:56:28.447429  | NonzeroRewardsMedian              21
2020-04-09 12:56:28.447440  | NonzeroRewardsMin                 21
2020-04-09 12:56:28.447453  | NonzeroRewardsMax                 21
2020-04-09 12:56:28.447465  | DiscountedReturnAverage           -1.85744
2020-04-09 12:56:28.447478  | DiscountedReturnStd                0.0435044
2020-04-09 12:56:28.447490  | DiscountedReturnMedian            -1.85323
2020-04-09 12:56:28.447503  | DiscountedReturnMin               -1.91956
2020-04-09 12:56:28.447515  | DiscountedReturnMax               -1.80722
2020-04-09 12:56:28.447528  | GameScoreAverage                 -21
2020-04-09 12:56:28.447540  | GameScoreStd                       0
2020-04-09 12:56:28.447553  | GameScoreMedian                  -21
2020-04-09 12:56:28.447565  | GameScoreMin                     -21
2020-04-09 12:56:28.447577  | GameScoreMax                     -21
2020-04-09 12:56:28.447589  | lossAverage                      nan
2020-04-09 12:56:28.447602  | lossStd                          nan
2020-04-09 12:56:28.447614  | lossMedian                       nan
2020-04-09 12:56:28.447626  | lossMin                          nan
2020-04-09 12:56:28.447638  | lossMax                          nan
2020-04-09 12:56:28.447651  | gradNormAverage                  nan
2020-04-09 12:56:28.447663  | gradNormStd                      nan
2020-04-09 12:56:28.447675  | gradNormMedian                   nan
2020-04-09 12:56:28.447687  | gradNormMin                      nan
2020-04-09 12:56:28.447700  | gradNormMax                      nan
2020-04-09 12:56:28.447712  | tdAbsErrAverage                  nan
2020-04-09 12:56:28.447725  | tdAbsErrStd                      nan
2020-04-09 12:56:28.447737  | tdAbsErrMedian                   nan
2020-04-09 12:56:28.447749  | tdAbsErrMin                      nan
2020-04-09 12:56:28.447761  | tdAbsErrMax                      nan
2020-04-09 12:56:28.447774  | -----------------------------  -------------
2020-04-09 12:56:28.447867  | dqn_pong_0 itr #779 Optimizing over 15 iterations.
0% [##                            ] 100% | ETA: 00:00:00Traceback (most recent call last):
  File "examples/example_5.py", line 68, in <module>
    n_parallel=args.n_parallel,
  File "examples/example_5.py", line 53, in build_and_train
    runner.train()
  File "/home/seita/rlpyt_astooke/rlpyt/runners/minibatch_rl.py", line 311, in train
    opt_info = self.algo.optimize_agent(itr, samples)
  File "/home/seita/rlpyt_astooke/rlpyt/algos/dqn/dqn.py", line 176, in optimize_agent
    loss, td_abs_errors = self.loss(samples_from_replay)
  File "/home/seita/rlpyt_astooke/rlpyt/algos/dqn/dqn.py", line 250, in loss
    raise NotImplementedError
NotImplementedError
```

The error happens here:

https://github.com/astooke/rlpyt/blob/a865f6712a049f9fd26500e924114e9582a6a5c2/rlpyt/algos/dqn/dqn.py#L246-L255

I'm not sure if there is a fix planned for this. However, the issue can be fixed by removing the GpuWaitResetCollector which will default to GpuResetCollector.  I'm curious if there is a need to have GpuWaitResetCollector in the Atari examples? [The docs suggest](https://rlpyt.readthedocs.io/en/latest/pages/collector.html#rlpyt.samplers.parallel.cpu.collectors.CpuWaitResetCollector) that the Cpu version seemed to be beneficial for Atari, interestingly.