### PR TITLE
Typing fix

### DIFF
--- a/rlpyt/samplers/base.py
+++ b/rlpyt/samplers/base.py
@@ -52,8 +52,9 @@ class BaseSampler:
         raise NotImplementedError
 
     def obtain_samples(self, itr):
+        # type: (int) -> Samples
         """Execute agent-environment interactions and return data batch."""
-        raise NotImplementedError  # type: Samples
+        raise NotImplementedError
 
     def evaluate_agent(self, itr):
         """Run offline agent evaluation, if applicable."""


### PR DESCRIPTION
Type comments are not prevalent in the codebase, but some type inference can be done automatically (e.g. using class definitions). This type comment is syntactically incorrect in that it causes mypy to throw an error. [python 2 backward compatible comments](https://mypy.readthedocs.io/en/stable/python2.html) either have to be on a line with a variable assignment, on a line with a function signature, immediately after a function signature, or on each line of a multiline function signature. The existing comment is neither. This small PR moves the comment to right after the function signature, and adds the type for the itr parameter too.

Longer term it would be really nice to have a stub file, if only the [auto-generated one](https://mypy.readthedocs.io/en/stable/stubgen.html), so that mypy can check the types of the classes used in this package.
@astooke 