### PR TITLE
fix inconsistent saving and loading of dqn agent

### DIFF
--- a/rlpyt/agents/dqn/dqn_agent.py
+++ b/rlpyt/agents/dqn/dqn_agent.py
@@ -33,11 +33,15 @@ class DqnAgent(EpsilonGreedyAgentMixin, BaseAgent):
         """Along with standard initialization, creates vector-valued epsilon
         for exploration, if applicable, with a different epsilon for each
         environment instance."""
+        _initial_model_state_dict = self.initial_model_state_dict
+        self.initial_model_state_dict = None  # don't let base agent try to initialize model
         super().initialize(env_spaces, share_memory,
             global_B=global_B, env_ranks=env_ranks)
         self.target_model = self.ModelCls(**self.env_model_kwargs,
             **self.model_kwargs)
-        self.target_model.load_state_dict(self.model.state_dict())
+        if _initial_model_state_dict is not None:
+            self.model.load_state_dict(_initial_model_state_dict['model'])
+            self.target_model.load_state_dict(_initial_model_state_dict['model'])
         self.distribution = EpsilonGreedy(dim=env_spaces.action.n)
         if env_ranks is not None:
             self.make_vec_eps(global_B, env_ranks)


### PR DESCRIPTION
The dqn agent creates a state_dict with model and target keys for saving. However it didn't load them correctly during initialization.
The base agent would then fail to load the model state dict.
