### PR TITLE
Fix AsyncPrioritizedSequenceReplayBuffer

### DIFF
--- a/rlpyt/replays/sequence/prioritized.py
+++ b/rlpyt/replays/sequence/prioritized.py
@@ -121,5 +121,5 @@ class PrioritizedSequenceReplayBuffer(PrioritizedSequenceReplay,
 
 
 class AsyncPrioritizedSequenceReplayBuffer(AsyncReplayBufferMixin,
-        PrioritizedSequenceReplay):
+        PrioritizedSequenceReplayBuffer):
     pass


### PR DESCRIPTION
There was a problem with the AsyncPrioritizedSequenceReplayBuffer. I think it inherited just from the wrong class. I have changed it to the same inheritance pattern that AsyncPrioritizedSequenceReplayFrameBuffer uses. Now it works.